### PR TITLE
added separate bundles for demographic and cause of death coding

### DIFF
--- a/input/fsh/EX_CodedContentBundles.fsh
+++ b/input/fsh/EX_CodedContentBundles.fsh
@@ -1,0 +1,47 @@
+
+Instance: CauseOfDeathCodedContentBundle-Example1
+InstanceOf: CauseOfDeathCodedContentBundle
+Usage: #example
+Description: "CauseofDeathCodedContentBundle-Example1"
+* insert AddMetaProfile(CauseOfDeathCodedContentBundle)
+* identifier.system = "http://nchs.cdc.gov/vrdr_id"
+* identifier.value = "000182"
+* identifier.extension[auxiliaryStateIdentifier1].valueString = "000000000001"
+* identifier.extension[auxiliaryStateIdentifier2].valueString = "100000000001"
+* timestamp = "2020-10-20T14:48:35.401641-04:00"
+* insert addentry(Observation, ActivityAtTimeOfDeath-Example1)
+* insert addentry(Observation, CodedRaceAndEthnicity-Example1)
+* insert addentry(Observation, ManualUnderlyingCauseOfDeath-Example1)
+* insert addentry(Observation, AutomatedUnderlyingCauseOfDeath-Example1)
+* insert addentry(Observation, RecordAxisCauseOfDeath-Example1)
+* insert addentry(Observation, EntityAxisCauseOfDeath-Example1)
+* insert addentry(Observation, PlaceOfInjury-Example1)
+* insert addentry(Parameter, CodingStatusValues-Example1)
+// Input Data
+* insert addentry(Observation, DecedentPregnancyStatus-Example1)
+* insert addentry(Observation, TobaccoUseContributedToDeath-Example1)
+* insert addentry(Observation, SurgeryDate-Example1)
+* insert addentry(Observation, ExaminerContacted-Example1)
+* insert addentry(Observation, MannerOfDeath-Example1)
+* insert addentry(Observation, InjuryIncident-Example1)
+* insert addentry(Procedure, DeathCertification-Example1)
+* insert addentry(Observation, CauseOfDeathPart1-Example1)
+* insert addentry(Observation, CauseOfDeathPart1-Example2)
+* insert addentry(Observation, CauseOfDeathPart2-Example1)
+* insert addentry(List, CauseOfDeathPathway-Example1)
+* insert addentry(Observation, AutopsyPerformedIndicator-Example1)
+
+
+Instance: DemographicCodedContentBundle-Example1
+InstanceOf: DemographicCodedContentBundle
+Usage: #example
+Description: "DemographicCodedContentBundle-Example1"
+* insert AddMetaProfile(DemographicCodedContentBundle)
+* identifier.system = "http://nchs.cdc.gov/vrdr_id"
+* identifier.value = "000182"
+* identifier.extension[auxiliaryStateIdentifier1].valueString = "000000000001"
+* identifier.extension[auxiliaryStateIdentifier2].valueString = "100000000001"
+* timestamp = "2020-10-20T14:48:35.401641-04:00"
+* insert addentry(Observation, InputRaceAndEthnicity-Example1)
+// Input Data
+* insert addentry(Observation, CodedRaceAndEthnicity-Example1)

--- a/input/fsh/SD_CodedContentBundles.fsh
+++ b/input/fsh/SD_CodedContentBundles.fsh
@@ -1,0 +1,67 @@
+Profile: CauseOfDeathCodedContentBundle
+Parent: Bundle
+Id: vrdr-cause-of-death-coded-content-bundle
+Title: "Cause of Death Coded Content Bundle (Bundle)"
+Description: "A bundle containing instances of the resources comprising cause of death coded content.
+
+This bundle is information-content equivalent to the traditional NCHS TRX format."
+* insert RequireMetaProfile(CauseOfDeathCodedContentBundle)
+* identifier ^short = "Death Certificate Number"
+* identifier ^definition = "A unique value used by the NCHS to identify a death record. The NCHS uniquely identifies death records by combining three concepts: the year of death (as a four digit number), the jurisdiction of death (as a two character jurisdiction identifier), and the death certificate number assigned by the jurisdiction (a number with up to six digits, left padded with zeros)."
+* identifier.value ^maxLength = 6
+* identifier.extension contains
+    AuxiliaryStateIdentifier1 named auxiliaryStateIdentifier1 0..1 and
+    AuxiliaryStateIdentifier2 named auxiliaryStateIdentifier2 0..1
+* type 1..1
+* type only code
+* type = #collection (exactly)
+* entry.resource 1..1 MS // each entry must have a resource
+* entry ^slicing.discriminator.type = #profile
+* entry ^slicing.discriminator.path = "resource"
+* entry ^slicing.rules = #open
+* entry ^slicing.description = "Slicing based on the profile"
+// Coded Content
+* insert BundleSlice(  ActivityAtTimeOfDeath,  0, 1,  ActivityAtTimeOfDeath,  ActivityAtTimeOfDeath,  ActivityAtTimeOfDeath)
+* insert BundleSlice(  AutomatedUnderlyingCauseOfDeath,  0, 1,  AutomatedUnderlyingCauseOfDeath,  AutomatedUnderlyingCauseOfDeath,  AutomatedUnderlyingCauseOfDeath)
+* insert BundleSlice(  ManualUnderlyingCauseOfDeath,  0, 1,  ManualUnderlyingCauseOfDeath,  ManualUnderlyingCauseOfDeath,  ManualUnderlyingCauseOfDeath)
+* insert BundleSlice(  EntityAxisCauseOfDeath,  0, 20,  EntityAxisCauseOfDeath,  EntityAxisCauseOfDeath,  EntityAxisCauseOfDeath)
+* insert BundleSlice(  RecordAxisCauseOfDeath,  0, 20,  RecordAxisCauseOfDeath,  RecordAxisCauseOfDeath,  RecordAxisCauseOfDeath)
+* insert BundleSlice(  PlaceOfInjury,  0, 1,  PlaceOfInjury,  PlaceOfInjury,  PlaceOfInjury)
+* insert BundleSlice(  CodingStatusValues,  0, 1,  CodingStatusValues,  CodingStatusValues,  CodingStatusValues)
+// Input Content
+* insert BundleSlice(  CauseOfDeathPart1,  0, 4,  CauseOfDeathPart1,  CauseOfDeathPart1,  CauseOfDeathPart1)
+* insert BundleSlice(  CauseOfDeathPathway,  0, 1,  CauseOfDeathPathway,  CauseOfDeathPathway,  CauseOfDeathPathway)
+* insert BundleSlice(  CauseOfDeathPart2,  0, 1,  CauseOfDeathPart2,  CauseOfDeathPart2,  CauseOfDeathPart2)
+* insert BundleSlice(  MannerOfDeath,  0, 1,  MannerOfDeath,  MannerOfDeath,  MannerOfDeath)
+* insert BundleSlice(  AutopsyPerformedIndicator,  0, 1,  AutopsyPerformedIndicator,  AutopsyPerformedIndicator,  AutopsyPerformedIndicator)
+* insert BundleSlice(  DeathCertification,  0, 1,  DeathCertification,  DeathCertification,  DeathCertification)
+* insert BundleSlice(  InjuryIncident,  0, 1,  InjuryIncident,  InjuryIncident,  InjuryIncident)
+* insert BundleSlice(  TobaccoUseContributedToDeath,  0, 1,  TobaccoUseContributedToDeath,  TobaccoUseContributedToDeath,  TobaccoUseContributedToDeath)
+* insert BundleSlice(  DecedentPregnancyStatus,  0, 1,  DecedentPregnancyStatus,  DecedentPregnancyStatus,  DecedentPregnancyStatus)
+* insert BundleSlice(  SurgeryDate,  0, 1,  SurgeryDate,  SurgeryDate,  SurgeryDate)
+
+
+Profile: DemographicCodedContentBundle
+Parent: Bundle
+Id: vrdr-demographic-coded-content-bundle
+Title: "Demographic Coded Content Bundle (Bundle)"
+Description: "A bundle containing instances of the resources comprising demographic (race and ethnicity) coded content.
+
+This bundle is information-content equivalent to the traditional NCHS MRE format."
+* insert RequireMetaProfile(CodedContentDocument)
+* identifier ^short = "Death Certificate Number"
+* identifier ^definition = "A unique value used by the NCHS to identify a death record. The NCHS uniquely identifies death records by combining three concepts: the year of death (as a four digit number), the jurisdiction of death (as a two character jurisdiction identifier), and the death certificate number assigned by the jurisdiction (a number with up to six digits, left padded with zeros)."
+* identifier.value ^maxLength = 6
+* identifier.extension contains
+    AuxiliaryStateIdentifier1 named auxiliaryStateIdentifier1 0..1 and
+    AuxiliaryStateIdentifier2 named auxiliaryStateIdentifier2 0..1
+* type 1..1
+* type only code
+* type = #collection (exactly)
+* entry.resource 1..1 MS // each entry must have a resource
+* entry ^slicing.discriminator.type = #profile
+* entry ^slicing.discriminator.path = "resource"
+* entry ^slicing.rules = #open
+* entry ^slicing.description = "Slicing based on the profile"
+* insert BundleSlice(  CodedRaceAndEthnicity,  0, 1,  CodedRaceAndEthnicity,  CodedRaceAndEthnicity,  CodedRaceAndEthnicity)
+* insert BundleSlice(  InputRaceAndEthnicity,  0, 1,  InputRaceAndEthnicity,  InputRaceAndEthnicity,  InputRaceAndEthnicity)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -116,7 +116,8 @@ groups:
     - StructureDefinition/vrdr-entity-axis-cause-of-death
     - StructureDefinition/vrdr-place-of-injury
     - StructureDefinition/vrdr-coded-race-and-ethnicity
-    - StructureDefinition/vrdr-coded-content-bundle
+    - StructureDefinition/vrdr-cause-of-death-coded-content-bundle
+    - StructureDefinition/vrdr-demographic-coded-content-bundle
     - StructureDefinition/vrdr-coding-status-values
   Extensions:
     name: Extensions


### PR DESCRIPTION
THis is to support the infamous option 3A that sends the Cause of Death and Demographic coding examples in FHIR bundles that mimic the content of TRX and MRE packets, respectively.